### PR TITLE
Adds a bower.json package description

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+	"name": "cookie",
+	"version": "1.0.0",
+	"main": "cookie.js",
+	"repository": {
+		"type": "git",
+		"url": "http://github.com/js-coder/cookie.js.git"
+	}
+}


### PR DESCRIPTION
This package is registered on Bower as a component, but as it lacked a `bower.json` it wasn't fully usable with various tools that consume Bower components. Adding this `bower.json` should correct the issue.