### PR TITLE
Allow falsey fallback values in cookie.get()

### DIFF
--- a/cookie.js
+++ b/cookie.js
@@ -113,7 +113,6 @@
 
 	cookie.get = function (keys, fallback) {
 
-		fallback = fallback || undefined;
 		var cookies = this.all();
 
 		if (utils.isArray(keys)) {


### PR DESCRIPTION
If you provide a fallback that evaluates to false to `cookie.get`, it is changed to undefined. This is not needed; if the fallback value is not provided, it will be evaluated as undefined anyways.

More importantly, this prevents clients from using "falsey" values as fallbacks, as they will always be converted to `undefined`.