### PR TITLE
cookie set README mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ cookie.set('key', 'value', {
 
 cookie.set({
 	key1: 'value1',
-	key2: 'value2',
-	{
+	key2: 'value2'
+}, {
 		expires: 7
-	}
 })
 ```
 


### PR DESCRIPTION
the origin usage will be trigger a syntax error that's a object never containing a value without key( below the key2 )
```javascript
cookie.set({
  	key1: 'value1',
  	key2: 'value2',
 	{
  		expires: 7
 	}
  })
```