### PR TITLE
Update cookie.js

### DIFF
--- a/cookie.js
+++ b/cookie.js
@@ -140,7 +140,12 @@
 
 		for (var i = 0, l = cookies.length; i < l; i++) {
 			var item = cookies[i].split('=');
-			result[decodeURIComponent(item[0])] = decodeURIComponent(item[1]);
+			var key = decodeURIComponent(item.shift());
+			// in case the cookie value has a not encoded '=', for example, the cookie is 'a=a=b'
+			// learn this from jquery.cookie.js
+			// ref https://github.com/carhartl/jquery-cookie/blob/master/jquery.cookie.js
+			var value = decodeURIComponent(item.join('='));
+			result[key] = value;
 		}
 
 		return result;


### PR DESCRIPTION
Fixed the following bug:
If there is a '=' in the cookie value, for example, the cookie is 'a=a=b',
the cookie.get('a') will return 'a', where the correct return value should be 'a=b'.

Learn the code from jquery.cookie.js, ref https://github.com/carhartl/jquery-cookie/blob/master/jquery.cookie.js