### PR TITLE
add ability to save cookie value without encode

### DIFF
--- a/cookie.js
+++ b/cookie.js
@@ -81,7 +81,8 @@
 
 			var secure = options.secure || this.defaults.secure ? ';secure' : '';
 
-			document.cookie = utils.escape(key) + '=' + utils.escape(value) + expires + path + domain + secure;
+			document.cookie = utils.escape(key) + '=' + 
+				(options.encode === false ? value : utils.escape(value)) + expires + path + domain + secure;
 
 		}
 


### PR DESCRIPTION
http://stackoverflow.com/questions/1969232/allowed-characters-in-cookies

Some characters, such as `=`, cannot be save as is. However they are actually correct characters according to the spec.

This patch add an extra option to allow saving the value as is.