### PR TITLE
fix: 1.3.0 introduces a breaking change (fixes #51)

### DIFF
--- a/src/cookie.js
+++ b/src/cookie.js
@@ -171,3 +171,4 @@ cookie.enabled = function () {
 };
 
 export default cookie;
+export {cookie}


### PR DESCRIPTION
it allows:

```js
impot {cookie} from 'cookie_js'
or
import cookie from 'cookie_js'
```